### PR TITLE
Spdlog vendor update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,20 +46,19 @@ macro(build_spdlog)
     list(APPEND extra_cmake_args "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
   endif()
   list(APPEND extra_cmake_args "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
-  list(APPEND extra_cmake_args "-DSPDLOG_BUILD_BENCH=OFF")
   list(APPEND extra_cmake_args "-DSPDLOG_BUILD_TESTS=OFF")
-  list(APPEND extra_cmake_args "-DSPDLOG_BUILD_EXAMPLES=OFF")
+  list(APPEND extra_cmake_args "-DSPDLOG_BUILD_EXAMPLE=OFF")
+  list(APPEND extra_cmake_args "-DSPDLOG_BUILD_SHARED=ON")
 
   include(ExternalProject)
-  # Get spdlog 1.3.1
-  externalproject_add(spdlog-1.3.1
-    URL https://github.com/gabime/spdlog/archive/v1.3.1.tar.gz
-    URL_MD5 3c17dd6983de2a66eca8b5a0b213d29f
+  # Get spdlog 1.5.0
+  externalproject_add(spdlog-1.5.0
+    URL https://github.com/gabime/spdlog/archive/v1.5.0.tar.gz
+    URL_MD5 a966eea01f81551527853d282896cb4d
     TIMEOUT 600
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
       ${extra_cmake_args}
-      -Wno-dev
   )
 
   # The external project will install to the build folder, but we'll install that on make install.
@@ -71,7 +70,7 @@ macro(build_spdlog)
   )
 endmacro()
 
-if(NOT spdlog_FOUND OR "${spdlog_VERSION}" VERSION_LESS 1.3.1)
+if(NOT spdlog_FOUND OR "${spdlog_VERSION}" VERSION_LESS 1.5.0)
   build_spdlog()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,9 @@ macro(build_spdlog)
   list(APPEND extra_cmake_args "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
   list(APPEND extra_cmake_args "-DSPDLOG_BUILD_TESTS=OFF")
   list(APPEND extra_cmake_args "-DSPDLOG_BUILD_EXAMPLE=OFF")
-  list(APPEND extra_cmake_args "-DSPDLOG_BUILD_SHARED=ON")
+  if (NOT WIN32)
+    list(APPEND extra_cmake_args "-DSPDLOG_BUILD_SHARED=ON")
+  endif()
 
   include(ExternalProject)
   # Get spdlog 1.5.0


### PR DESCRIPTION
Updates spdlog to version 1.5.0, which is the version in Ubuntu Focal.  For consistencies sake, we also change macOS and Windows to use the "built" library instead of the header-only library.

Part of solving https://github.com/ros2/rcl_logging/issues/26