### PR TITLE
Fix CMake Linter warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ macro(build_spdlog)
   list(APPEND extra_cmake_args "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
   list(APPEND extra_cmake_args "-DSPDLOG_BUILD_TESTS=OFF")
   list(APPEND extra_cmake_args "-DSPDLOG_BUILD_EXAMPLE=OFF")
-  if (NOT WIN32)
+  if(NOT WIN32)
     list(APPEND extra_cmake_args "-DSPDLOG_BUILD_SHARED=ON")
   endif()
 


### PR DESCRIPTION
Fix CMake Linter warning

* https://ci.ros2.org/view/nightly/job/nightly_linux_debug/1490/testReport/junit/spdlog_vendor/lint_cmake/whitespace_extra__CMakeLists_txt_51_/
* https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_debug/1135/testReport/junit/spdlog_vendor/lint_cmake/whitespace_extra__CMakeLists_txt_51_/
* https://ci.ros2.org/view/nightly/job/nightly_linux-armhf_debug/417/testReport/junit/spdlog_vendor/lint_cmake/whitespace_extra__CMakeLists_txt_51_/
* https://ci.ros2.org/view/nightly/job/nightly_osx_debug/1560/testReport/junit/spdlog_vendor/lint_cmake/whitespace_extra__CMakeLists_txt_51_/

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>