### PR TITLE
Remove included extra ament_copyright

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,10 +87,6 @@ endif()
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
-  find_package(ament_cmake_copyright QUIET)
-  if(ament_cmake_copyright_FOUND)
-    ament_copyright()
-  endif()
 endif()
 
 # this ensures that the package has an environment hook setting the PATH

--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,6 @@
 
   <depend>spdlog</depend>
 
-  <test_depend>ament_cmake_copyright</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
The extra copyright added at #11 colides with the proposed fix to `ament_lint` proposed at [ament_lint#247](https://github.com/ament/ament_lint/pull/247).

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>