### PR TITLE
Always use 'lib' directory over 'lib64'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ macro(build_spdlog)
   list(APPEND extra_cmake_args "-DSPDLOG_BUILD_EXAMPLE=OFF")
   if(NOT WIN32)
     list(APPEND extra_cmake_args "-DSPDLOG_BUILD_SHARED=ON")
+    list(APPEND extra_cmake_args "-DCMAKE_INSTALL_LIBDIR=lib")
   endif()
 
   include(ExternalProject)


### PR DESCRIPTION
The rest of ROS 2 is using 'lib', so if we continue to use 'lib64', we'd need to add a hook to ensure that 'lib64' ends up in `LD_LIBRARY_PATH`. This is an easier solution.

This is a problem in 6 vendor packages in ROS 2, but this is the first one to cause build failures during RPM packaging. The downstream package `rcl_logging_spdlog` is able to build against this vendor package successfully because it finds this package via CMake. Packages downstream of `rcl_logging_spdlog`, however, are not configured to look for `spdlog` via CMake (nor should they be), so the library is expected to resolved via runtime mechanisms. Since `lib64` isn't in the `LD_LIBRARY_PATH` crafted by the hooks invoked during `setup.sh`, the downstream build fails.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13593)](http://ci.ros2.org/job/ci_linux/13593/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8476)](http://ci.ros2.org/job/ci_linux-aarch64/8476/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11306)](http://ci.ros2.org/job/ci_osx/11306/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13650)](http://ci.ros2.org/job/ci_windows/13650/)

Linux Overlay before: [![Build Status](https://build.ros2.org/buildStatus/icon?job=Rci__overlay_ubuntu_focal_amd64&build=13)](https://build.ros2.org/view/Rci/job/Rci__overlay_ubuntu_focal_amd64/13/)
Linux Overlay after: [![Build Status](https://build.ros2.org/buildStatus/icon?job=Rci__overlay_ubuntu_focal_amd64&build=14)](https://build.ros2.org/view/Rci/job/Rci__overlay_ubuntu_focal_amd64/14/)

The colcon builds on Ubuntu seem to show the same results before and after - everything ends up in the `lib` directory. On Fedora and RHEL, the 6 packages seem to use `lib64` on in both colcon builds and RPM builds. In the Ubuntu debs, only `console_bridge` demonstrates a deviation, where it uses the debian-style `lib/{arch}-linux-gnu` directory.