### PR TITLE
Shorten some excessively long lines of CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,8 @@ if(NOT spdlog_FOUND OR "${spdlog_VERSION}" VERSION_LESS 1.5.0)
   build_spdlog()
 endif()
 
-# TODO(blast545): This section and package.xml should be updated once copyright auto is solved. See: https://github.com/ament/ament_lint/issues/237
+# TODO(blast545): This section and package.xml should be updated once copyright auto is solved.
+# See: https://github.com/ament/ament_lint/issues/237
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()


### PR DESCRIPTION
The line length enforcement in ament_lint_cmake has been broken for some time, but will be fixed by ament/ament_lint#236. This change brings this package into compliance with a 120 column limit.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13645)](http://ci.ros2.org/job/ci_linux/13645/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8525)](http://ci.ros2.org/job/ci_linux-aarch64/8525/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11360)](http://ci.ros2.org/job/ci_osx/11360/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13709)](http://ci.ros2.org/job/ci_windows/13709/)