### PR TITLE
Fixes policy CMP0135 warning for CMake >= 3.24

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ find_package(ament_cmake REQUIRED)
 ament_add_default_options()
 
 # Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
-if (POLICY CMP0135)
-  cmake_policy(SET CMP0135 OLD)
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
 endif()
 
 option(FORCE_BUILD_VENDOR_PKG

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ project(spdlog_vendor)
 find_package(ament_cmake REQUIRED)
 ament_add_default_options()
 
+# Avoid DOWNLOAD_EXTRACT_TIMESTAMP warning for CMake >= 3.24
+if (POLICY CMP0135)
+  cmake_policy(SET CMP0135 OLD)
+endif()
+
 option(FORCE_BUILD_VENDOR_PKG
   "Build spdlog from source, even if system-installed package is available"
   OFF)


### PR DESCRIPTION
Signed-off-by: Crola1702 <cristobal.arroyo@ekumenlabs.com>

Reference build: https://ci.ros2.org/view/nightly/job/nightly_win_deb/2473/

[This](https://cmake.org/cmake/help/latest/policy/CMP0135.html) warning started appearing on new Windows machines. It’s caused by a new CMake version (3.24) that expects this policy to be set.

This PR sets CMP0135 policy in CMakeLists.txt

CI launch:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=17255)](http://ci.ros2.org/job/ci_linux/17255/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11794)](http://ci.ros2.org/job/ci_linux-aarch64/11794/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=17735)](http://ci.ros2.org/job/ci_windows/17735/)