### PR TITLE
Update to spdlog 1.9.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,9 +60,9 @@ macro(build_spdlog)
 
   include(ExternalProject)
 
-  externalproject_add(spdlog-1.9.1
-    URL https://github.com/gabime/spdlog/archive/v1.9.1.tar.gz
-    URL_MD5 97d556dd35dbc362e05a2e74a33f6d93
+  externalproject_add(spdlog-1.9.2
+    URL https://github.com/gabime/spdlog/archive/v1.9.2.tar.gz
+    URL_MD5 cee7f3d31178a00791d7a22c6738df6d
     TIMEOUT 600
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install


### PR DESCRIPTION
Corresponds to the Jammy package: https://packages.ubuntu.com/jammy/libspdlog-dev

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=18463)](http://ci.ros2.org/job/ci_linux/18463/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=13009)](http://ci.ros2.org/job/ci_linux-aarch64/13009/)
* Linux-rhel [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=370)](https://ci.ros2.org/job/ci_linux-rhel/370/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=19156)](http://ci.ros2.org/job/ci_windows/19156/)